### PR TITLE
fix: 사파리 드래그&드랍 에러 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/src/pages/emails/EmailEditingStep03.jsx
+++ b/src/pages/emails/EmailEditingStep03.jsx
@@ -176,7 +176,10 @@ export default function EmailEditingStep03() {
       $dragItemIndexRef.current - $dragOverItemIndexRef.current,
     );
 
-    if (e.dataTransfer.effectAllowed === 'move') {
+    if (
+      e.dataTransfer.effectAllowed === 'move' ||
+      !e.dataTransfer.types.length
+    ) {
       $dragItemRef.current.blur();
 
       if (


### PR DESCRIPTION
사파리에서 발생하는 작업대내의 요소 드래그&드랍시 에러를 수정하였습니다.

사파리 브라우저만 e.dataTransfer.effectAllowed 값이 설정해준 값으로 적용되지않고 항상 copyMove로 고정되어서 분기처리시 조건을 추가하였습니다.